### PR TITLE
Add keep_artifact option to be able to remove the source AMI after copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 
 ### Description
 
-This plugin fills a gap in a lot of AWS image bakery workflows where the source image built by any of Packer's Amazon builders (EBS, Chroot, Instance etc.) needs to be copied to a number of target accounts. 
+This plugin fills a gap in a lot of AWS image bakery workflows where the source image built by any of Packer's Amazon builders (EBS, Chroot, Instance etc.) needs to be copied to a number of target accounts.
 
 For each `region:ami-id` built, the plugin will copy the image and tags, and optionally encrypt the target AMI and wait for it to become active.
-
 
 ### Installation
 
@@ -20,6 +19,7 @@ This is a packer _plugin_. Please read the plugin [documentation](https://www.pa
 You can download the latest binary for your architecture from the [releases page](https://github.com/martinbaillie/packer-post-processor-ami-copy/releases/latest).
 
 ### Usage
+
 ```json
 "builders": [
   {
@@ -44,13 +44,17 @@ You can download the latest binary for your architecture from the [releases page
 ```
 
 ### Configuration
+
 Type: `ami-copy`
 
 Required:
+
 - `ami_users` (array of strings) - A list of account IDs to copy the images to. NOTE: you must share AMI and snapshot access in the builder through `ami_users` and `snapshot_users` respectively.
 
 Optional:
+
 - `copy_concurrency` (integer) - Limit the number of copies executed in parallel (default: unlimited).
 - `encrypt_boot` (boolean) - create the copy with an encrypted EBS volume in the target accounts
 - `kms_key_id` (string) - the ID of the KMS key to use for boot volume encryption. (default EBS KMS key used otherwise).
 - `ensure_available` (boolean) - wait until the AMI becomes available in the copy target account(s)
+- `keep_artifact` (boolean) - remove the original generated AMI after copy (default: true)

--- a/amicopy/amicopy.go
+++ b/amicopy/amicopy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"errors"
+
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/packer"
 )
@@ -21,6 +22,7 @@ type AmiCopy struct {
 	Output          *ec2.CopyImageOutput
 	SourceImage     *ec2.Image
 	EnsureAvailable bool
+	KeepArtifact    bool
 }
 
 // Copy will perform an EC2 copy based on the `Input` field.


### PR DESCRIPTION
This is a feature that give the choice whether to keep the source AMI
or not after copy.

It solves the use case where we have to copy an AMI that is using
encrypted snapshots across accounts.

We can only share snapshots encrypted with Customer Managed Keys, but
the resulting copied AMI is using the default `aws/ebs` KMS key.

For consistency across all accounts we can then use the post processor to copy the AMI on the source account itself then drop the intermediate AMI that used the CMK.