### PR TITLE
Add AMI manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Optional:
 - `kms_key_id` (string) - the ID of the KMS key to use for boot volume encryption. (default EBS KMS key used otherwise).
 - `ensure_available` (boolean) - wait until the AMI becomes available in the copy target account(s)
 - `keep_artifact` (boolean) - remove the original generated AMI after copy (default: true)
-- `manifest_output` (string) - the name of the file we output AMI IDs to
+- `manifest_output` (string) - the name of the file we output AMI IDs to, in JSON format (default: no manifest file is written)

--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ Optional:
 - `kms_key_id` (string) - the ID of the KMS key to use for boot volume encryption. (default EBS KMS key used otherwise).
 - `ensure_available` (boolean) - wait until the AMI becomes available in the copy target account(s)
 - `keep_artifact` (boolean) - remove the original generated AMI after copy (default: true)
+- `manifest_output` (string) - the name of the file we output AMI IDs to

--- a/amicopy/amicopy.go
+++ b/amicopy/amicopy.go
@@ -25,6 +25,13 @@ type AmiCopy struct {
 	KeepArtifact    bool
 }
 
+// AmiManifest holds the data about the resulting copied image
+type AmiManifest struct {
+	AccountID string `json:"account_id"`
+	Region    string `json:"region"`
+	ImageID   string `json:"image_id"`
+}
+
 // Copy will perform an EC2 copy based on the `Input` field.
 // It will also call Tag to copy the source tags, if any.
 func (ac *AmiCopy) Copy(ui *packer.Ui) (err error) {

--- a/amicopy/amicopy.go
+++ b/amicopy/amicopy.go
@@ -66,7 +66,7 @@ func (ac *AmiCopyImpl) Copy(ui *packer.Ui) (err error) {
 			if *image.State == ec2.ImageStateAvailable {
 				return nil
 			}
-			(*ui).Say(fmt.Sprintf("Waiting one minute (%d/30) for AMI to become available, current state: %s for image %s on account %s", i, *image.State, *image.ImageId, ac.TargetAccountID))
+			(*ui).Say(fmt.Sprintf("Waiting one minute (%d/30) for AMI to become available, current state: %s for image %s on account %s", i, *image.State, *image.ImageId, ac.targetAccountID))
 			time.Sleep(time.Duration(1) * time.Minute)
 		}
 		return errors.New(fmt.Sprintf("Timed out waiting for image %s to copy to account %s", *ac.output.ImageId, ac.targetAccountID))

--- a/amicopy/amicopy.go
+++ b/amicopy/amicopy.go
@@ -14,12 +14,21 @@ import (
 	"github.com/hashicorp/packer/packer"
 )
 
-// AmiCopy holds data and methods related to copying an image.
-type AmiCopy struct {
-	TargetAccountID string
+// AmiCopy defines the interface to copy images
+type AmiCopy interface {
+	Copy(ui *packer.Ui) error
+	Input() *ec2.CopyImageInput
+	Output() *ec2.CopyImageOutput
+	Tag() error
+	TargetAccountID() string
+}
+
+// AmiCopyImpl holds data and methods related to copying an image.
+type AmiCopyImpl struct {
+	targetAccountID string
 	EC2             *ec2.EC2
-	Input           *ec2.CopyImageInput
-	Output          *ec2.CopyImageOutput
+	input           *ec2.CopyImageInput
+	output          *ec2.CopyImageOutput
 	SourceImage     *ec2.Image
 	EnsureAvailable bool
 	KeepArtifact    bool
@@ -34,12 +43,12 @@ type AmiManifest struct {
 
 // Copy will perform an EC2 copy based on the `Input` field.
 // It will also call Tag to copy the source tags, if any.
-func (ac *AmiCopy) Copy(ui *packer.Ui) (err error) {
-	if err = ac.Input.Validate(); err != nil {
+func (ac *AmiCopyImpl) Copy(ui *packer.Ui) (err error) {
+	if err = ac.input.Validate(); err != nil {
 		return err
 	}
 
-	if ac.Output, err = ac.EC2.CopyImage(ac.Input); err != nil {
+	if ac.output, err = ac.EC2.CopyImage(ac.input); err != nil {
 		return err
 	}
 
@@ -50,7 +59,7 @@ func (ac *AmiCopy) Copy(ui *packer.Ui) (err error) {
 	if ac.EnsureAvailable {
 		(*ui).Say("Going to wait for image to be in available state")
 		for i := 1; i <= 30; i++ {
-			image, err := LocateSingleAMI(*ac.Output.ImageId, ac.EC2)
+			image, err := LocateSingleAMI(*ac.output.ImageId, ac.EC2)
 			if err != nil && image == nil {
 				return err
 			}
@@ -60,14 +69,34 @@ func (ac *AmiCopy) Copy(ui *packer.Ui) (err error) {
 			(*ui).Say(fmt.Sprintf("Waiting one minute (%d/30) for AMI to become available, current state: %s for image %s on account %s", i, *image.State, *image.ImageId, ac.TargetAccountID))
 			time.Sleep(time.Duration(1) * time.Minute)
 		}
-		return errors.New(fmt.Sprintf("Timed out waiting for image %s to copy to account %s", *ac.Output.ImageId, ac.TargetAccountID))
+		return errors.New(fmt.Sprintf("Timed out waiting for image %s to copy to account %s", *ac.output.ImageId, ac.targetAccountID))
 	}
 
 	return nil
 }
 
+func (ac *AmiCopyImpl) Input() *ec2.CopyImageInput {
+	return ac.input
+}
+
+func (ac *AmiCopyImpl) SetInput(input *ec2.CopyImageInput) {
+	ac.input = input
+}
+
+func (ac *AmiCopyImpl) Output() *ec2.CopyImageOutput {
+	return ac.output
+}
+
+func (ac *AmiCopyImpl) TargetAccountID() string {
+	return ac.targetAccountID
+}
+
+func (ac *AmiCopyImpl) SetTargetAccountID(id string) {
+	ac.targetAccountID = id
+}
+
 // Tag will copy tags from the source image to the target (if any).
-func (ac *AmiCopy) Tag() (err error) {
+func (ac *AmiCopyImpl) Tag() (err error) {
 	if len(ac.SourceImage.Tags) == 0 {
 		return nil
 	}
@@ -75,7 +104,7 @@ func (ac *AmiCopy) Tag() (err error) {
 	// Retry creating tags for about 2.5 minutes
 	return common.Retry(0.2, 30, 11, func(i uint) (bool, error) {
 		_, err := ac.EC2.CreateTags(&ec2.CreateTagsInput{
-			Resources: []*string{ac.Output.ImageId},
+			Resources: []*string{ac.output.ImageId},
 			Tags:      ac.SourceImage.Tags,
 		})
 

--- a/post-processor.go
+++ b/post-processor.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
+	"io/ioutil"
 	"strconv"
 	"strings"
 	"sync"
@@ -284,20 +284,9 @@ func amisFromArtifactID(artifactID string) (amis []*ami) {
 }
 
 func writeManifests(output string, manifests []*amicopy.AmiManifest) error {
-	f, err := os.Open(output)
+	rawManifest, err := json.Marshal(manifests)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	for m := range manifests {
-		rawManifest, err := json.Marshal(m)
-		if err != nil {
-			return err
-		}
-		_, err = f.Write(rawManifest)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return ioutil.WriteFile(output, rawManifest, 0644)
 }

--- a/post-processor.go
+++ b/post-processor.go
@@ -249,14 +249,21 @@ func copyAMIs(copies []amicopy.AmiCopy, ui packer.Ui, manifestOutput string, con
 
 	if manifestOutput != "" {
 		manifests := []*amicopy.AmiManifest{}
-		for manifest := range amiManifests {
-			manifests = append(manifests, manifest)
+	LOOP:
+		for {
+			select {
+			case m := <-amiManifests:
+				manifests = append(manifests, m)
+			default:
+				break LOOP
+			}
 		}
 		err := writeManifests(manifestOutput, manifests)
 		if err != nil {
 			ui.Say(fmt.Sprintf("Unable to write out manifest to %s: %s", manifestOutput, err))
 		}
 	}
+	close(amiManifests)
 
 	return copyErrs
 }

--- a/post-processor.go
+++ b/post-processor.go
@@ -115,11 +115,6 @@ func (p *PostProcessor) PostProcess(
 		return artifact, keepArtifactBool, err
 	}
 
-	manifestOutput := p.config.ManifestOutput
-	if manifestOutput == "" {
-		manifestOutput = "packer-ami-copy-manifest.json"
-	}
-
 	// Copy futures
 	var (
 		amis   = amisFromArtifactID(artifact.Id())
@@ -232,13 +227,15 @@ func (p *PostProcessor) PostProcess(
 	close(copyTasks)
 	wg.Wait()
 
-	manifests := []*amicopy.AmiManifest{}
-	for manifest := range amiManifests {
-		manifests = append(manifests, manifest)
-	}
-	err = writeManifests(manifestOutput, manifests)
-	if err != nil {
-		ui.Say(fmt.Sprintf("Unable to write out manifest to %s: %s", manifestOutput, err))
+	if p.config.ManifestOutput != "" {
+		manifests := []*amicopy.AmiManifest{}
+		for manifest := range amiManifests {
+			manifests = append(manifests, manifest)
+		}
+		err = writeManifests(p.config.ManifestOutput, manifests)
+		if err != nil {
+			ui.Say(fmt.Sprintf("Unable to write out manifest to %s: %s", p.config.ManifestOutput, err))
+		}
 	}
 
 	if copyErrs > 0 {

--- a/post-processor.go
+++ b/post-processor.go
@@ -171,7 +171,7 @@ func (p *PostProcessor) PostProcess(
 				Encrypted:     aws.Bool(p.config.AMIEncryptBootVolume),
 			})
 
-			copies = append(copies)
+			copies = append(copies, amiCopy)
 		}
 	}
 

--- a/post-processor.go
+++ b/post-processor.go
@@ -119,7 +119,7 @@ func (p *PostProcessor) PostProcess(
 	var (
 		amis   = amisFromArtifactID(artifact.Id())
 		users  = p.config.AMIUsers
-		copies []*amicopy.AmiCopy
+		copies []amicopy.AmiCopy
 	)
 	for _, ami := range amis {
 		var source *ec2.Image
@@ -156,34 +156,46 @@ func (p *PostProcessor) PostProcess(
 				}
 			}
 
-			copies = append(copies, &amicopy.AmiCopy{
+			amiCopy := &amicopy.AmiCopyImpl{
 				EC2:             conn,
 				SourceImage:     source,
-				TargetAccountID: user,
-				Input: &ec2.CopyImageInput{
-					Name:          aws.String(name),
-					Description:   aws.String(description),
-					SourceImageId: aws.String(ami.id),
-					SourceRegion:  aws.String(ami.region),
-					KmsKeyId:      aws.String(p.config.AMIKmsKeyId),
-					Encrypted:     aws.Bool(p.config.AMIEncryptBootVolume),
-				},
 				EnsureAvailable: p.config.EnsureAvailable,
+			}
+			amiCopy.SetTargetAccountID(user)
+			amiCopy.SetInput(&ec2.CopyImageInput{
+				Name:          aws.String(name),
+				Description:   aws.String(description),
+				SourceImageId: aws.String(ami.id),
+				SourceRegion:  aws.String(ami.region),
+				KmsKeyId:      aws.String(p.config.AMIKmsKeyId),
+				Encrypted:     aws.Bool(p.config.AMIEncryptBootVolume),
 			})
+
+			copies = append(copies)
 		}
 	}
 
+	copyErrs := copyAMIs(copies, ui, p.config.ManifestOutput, p.config.CopyConcurrency)
+	if copyErrs > 0 {
+		return artifact, true, fmt.Errorf(
+			"%d/%d AMI copies failed, manual reconciliation may be required", copyErrs, len(copies))
+	}
+
+	return artifact, keepArtifactBool, nil
+}
+
+func copyAMIs(copies []amicopy.AmiCopy, ui packer.Ui, manifestOutput string, concurrencyCount int) int32 {
 	// Copy execution loop
 	var (
 		copyCount    = len(copies)
-		copyTasks    = make(chan *amicopy.AmiCopy, copyCount)
+		copyTasks    = make(chan amicopy.AmiCopy, copyCount)
 		amiManifests = make(chan *amicopy.AmiManifest, copyCount)
 		copyErrs     int32
 		wg           sync.WaitGroup
 	)
 	var workers int
 	{
-		if workers = p.config.CopyConcurrency; workers == 0 {
+		if workers = concurrencyCount; workers == 0 {
 			workers = copyCount
 		}
 	}
@@ -192,29 +204,37 @@ func (p *PostProcessor) PostProcess(
 		go func() {
 			defer wg.Done()
 			for c := range copyTasks {
-				ui.Say(fmt.Sprintf("[%s] Copying %s to account %s (encrypted: %t)",
-					*c.Input.SourceRegion,
-					*c.Input.SourceImageId,
-					c.TargetAccountID,
-					*c.Input.Encrypted),
+				input := c.Input()
+				ui.Say(
+					fmt.Sprintf(
+						"[%s] Copying %s to account %s (encrypted: %t)",
+						*input.SourceRegion,
+						*input.SourceImageId,
+						c.TargetAccountID(),
+						*input.Encrypted,
+					),
 				)
-				if err = c.Copy(&ui); err != nil {
+				if err := c.Copy(&ui); err != nil {
 					ui.Say(err.Error())
 					atomic.AddInt32(&copyErrs, 1)
 					continue
 				}
+				output := c.Output()
 				manifest := &amicopy.AmiManifest{
-					AccountID: c.TargetAccountID,
-					Region:    *c.Input.SourceRegion,
-					ImageID:   *c.Output.ImageId,
+					AccountID: c.TargetAccountID(),
+					Region:    *input.SourceRegion,
+					ImageID:   *output.ImageId,
 				}
 				amiManifests <- manifest
 
-				ui.Say(fmt.Sprintf("[%s] Finished copying %s to %s (copied id: %s)",
-					*c.Input.SourceRegion,
-					*c.Input.SourceImageId,
-					c.TargetAccountID,
-					*c.Output.ImageId),
+				ui.Say(
+					fmt.Sprintf(
+						"[%s] Finished copying %s to %s (copied id: %s)",
+						*input.SourceRegion,
+						*input.SourceImageId,
+						c.TargetAccountID(),
+						*output.ImageId,
+					),
 				)
 			}
 		}()
@@ -227,22 +247,18 @@ func (p *PostProcessor) PostProcess(
 	close(copyTasks)
 	wg.Wait()
 
-	if p.config.ManifestOutput != "" {
+	if manifestOutput != "" {
 		manifests := []*amicopy.AmiManifest{}
 		for manifest := range amiManifests {
 			manifests = append(manifests, manifest)
 		}
-		err = writeManifests(p.config.ManifestOutput, manifests)
+		err := writeManifests(manifestOutput, manifests)
 		if err != nil {
-			ui.Say(fmt.Sprintf("Unable to write out manifest to %s: %s", p.config.ManifestOutput, err))
+			ui.Say(fmt.Sprintf("Unable to write out manifest to %s: %s", manifestOutput, err))
 		}
 	}
 
-	if copyErrs > 0 {
-		return artifact, true, fmt.Errorf(
-			"%d/%d AMI copies failed, manual reconciliation may be required", copyErrs, copyCount)
-	}
-	return artifact, keepArtifactBool, nil
+	return copyErrs
 }
 
 // ami encapsulates simplistic details about an AMI.

--- a/post-processor_test.go
+++ b/post-processor_test.go
@@ -4,13 +4,74 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/builder/amazon/ebs"
 	"github.com/hashicorp/packer/packer"
+	"github.com/martinbaillie/packer-post-processor-ami-copy/amicopy"
 )
 
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
 	var _ packer.PostProcessor = new(PostProcessor)
+}
+
+func TestConcurrentCopy(t *testing.T) {
+	ui := &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	}
+	copies := []amicopy.AmiCopy{
+		&MockAmiCopy{},
+		&MockAmiCopy{},
+	}
+	errs := copyAMIs(copies, ui, "", 2)
+	if errs > 0 {
+		t.Fatalf("Too many errors %d", errs)
+	}
+}
+
+func TestConcurrentCopyWithManifest(t *testing.T) {
+	ui := &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	}
+	copies := []amicopy.AmiCopy{
+		&MockAmiCopy{},
+		&MockAmiCopy{},
+	}
+	errs := copyAMIs(copies, ui, "testdata/manifest.json", 2)
+	if errs > 0 {
+		t.Fatalf("Too many errors %d", errs)
+	}
+}
+
+type MockAmiCopy struct{}
+
+func (m *MockAmiCopy) Copy(ui *packer.Ui) error {
+	return nil
+}
+
+func (m *MockAmiCopy) Input() *ec2.CopyImageInput {
+	return &ec2.CopyImageInput{
+		SourceRegion:  aws.String("ap-southeast-2"),
+		SourceImageId: aws.String("ami-abcd1234"),
+		Encrypted:     aws.Bool(true),
+	}
+}
+
+func (m *MockAmiCopy) Output() *ec2.CopyImageOutput {
+	return &ec2.CopyImageOutput{
+		ImageId: aws.String("ami-1234abcd"),
+	}
+}
+
+func (m *MockAmiCopy) Tag() error {
+	return nil
+}
+
+func (m *MockAmiCopy) TargetAccountID() string {
+	return "012345678910"
 }
 
 // TODO: AWS API mocking


### PR DESCRIPTION
It's useful to output the AMI ID in a well formatted way, to enable automated scripts to read it.
Much like the [Packer manifest](https://www.packer.io/docs/post-processors/manifest.html) post processor, we output a JSON file with the AMI IDs.
Unfortunately we can't re-use that format, as we're unable to add the AccountID to it.

I also added some tests of the concurrency code, to help fix a deadlock I introduced.